### PR TITLE
Adjust headers so browers will send If-Modified-Since header

### DIFF
--- a/custom_components/custom_updater.py
+++ b/custom_components/custom_updater.py
@@ -15,7 +15,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.helpers.event import async_track_time_interval
 
-VERSION = '4.2.17'
+VERSION = '4.2.18'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/custom_updater.py
+++ b/custom_components/custom_updater.py
@@ -312,9 +312,7 @@ class CustomCardsView(HomeAssistantView):
                 path=path)
             _LOGGER.debug(msg)
             resp = web.FileResponse(file)
-            resp.headers["Cache-Control"] = "no-store, no-cache, must-revalidate"
-            resp.headers["Pragma"] = "no-cache"
-            resp.headers["Expires"] = "0"
+            resp.headers["Cache-Control"] = "max-age=0, must-revalidate"
             return resp
         else:
             _LOGGER.error("Tried to serve up '%s' but it does not exist", file)


### PR DESCRIPTION
I tested this with Chrome. This change causes Chrome (and maybe other browsers) to send the If-Modified-Since header. aiohttp.web will take care of the rest to send back a 304 response so we don't have to send everything back down.

Closes #125
